### PR TITLE
Implement board persistence for example application "faketrello"

### DIFF
--- a/examples/faketrello/appdelegate.h
+++ b/examples/faketrello/appdelegate.h
@@ -18,6 +18,11 @@ signals:
 
 public slots:
 
+    QByteArray stringifyModel(); //NPM
+    void persistModel(const QString& filePath); //NPM
+    QByteArray stringifyBoard(); //NPM
+    void persistBoard(const QString& filePath); //NPM
+
     void addList();
 
     void addCard(const QString& listUuid);

--- a/examples/faketrello/board.h
+++ b/examples/faketrello/board.h
@@ -30,8 +30,11 @@ public:
 
     int indexOfList(const QString& listUuid);
 
-    // Load from file, but now it just load dummy data for demo
-    void load();
+    // NPM: Load persisted board from file.
+    void load(const QString &persistFilePath);
+
+    // NPM: Load initial board if persistence file missing or malformed.
+    void failsafeLoad();
 
     QVariantMap toMap() const;
 

--- a/examples/faketrello/main.qml
+++ b/examples/faketrello/main.qml
@@ -1,9 +1,10 @@
 import QtQuick 2.3
 import QtQuick.Window 2.2
 import QtQuick.Layouts 1.1
+import QtQuick.Controls 1.1
 import "./views"
 
-Window {
+ApplicationWindow {
     id: window
     width: 640
     height: 480
@@ -23,5 +24,16 @@ Window {
 
     }
 
+    // NPM: Persist the model to file on application close.
+    // see https://github.com/benlau/qsyncable/issues/2
+    // BUG: when running on Android, putting application in background and closing
+    // (via swipe or close window button) doesn't call this -- you just get
+    // '"org.qtproject.example.faketrello" died.' message before anything can be done.
+    // However,  closing android app with back button works and persists the board.
+    onClosing: {
+        //console.log("Model=" + App.stringifyModel());
+        console.log("Exiting application... Persisting model to file " + PersistFilePath);
+        App.persistModel(PersistFilePath);
+        close.accepted = true;
+    }
 }
-


### PR DESCRIPTION
As discussed in https://github.com/benlau/qsyncable/issues/2 here is an implementation of persistence for the example "faketrello" application.

As-is, there is currently a "bug" on Android, in that the application won't persist if the application is backgrounded via task manager and then closed. It will correctly close and persist on Android using the back button. 